### PR TITLE
chat sdk test cases

### DIFF
--- a/playwright/integrations/authenticated-chat.spec.ts
+++ b/playwright/integrations/authenticated-chat.spec.ts
@@ -2,6 +2,7 @@ import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
 import { test, expect } from '@playwright/test';
 import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
+import ACSEndpoints from '../utils/ACSEndpoints';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('AuthenticatedChat');
@@ -149,5 +150,55 @@ test.describe('AuthenticatedChat @AuthenticatedChat', () => {
         expect(liveChatMapRecordResponse.status()).toBe(200);
         expect(liveWorkItemDetailsResponseDataJson.State).not.toBe('Closed');
         expect(sessionInitCalls.length).toBe(1);
+    });
+
+    test('ChatSDK.sendMessage() should send the message masked for authenticated chat', async ({ page }) => {
+        await page.goto(testPage);
+
+        const content = "4111111111111111";
+
+        const [getMessagesRequest, getMessagesResponse, runtimeContext] = await Promise.all([
+            page.waitForRequest(request => {
+                return request.url().match(ACSEndpoints.getMessagesPathPattern)?.length >= 0 && request.method() === 'GET';
+            }),
+            page.waitForResponse(response => {
+                return response.url().match(ACSEndpoints.getMessagesPathPattern)?.length >= 0 && response.request().method() === 'GET'
+            }),
+            await page.evaluate(async ({ omnichannelConfig, content }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+                const chatSDKConfig = {
+                    getAuthToken: async () => {
+                        return omnichannelConfig.token;
+                    }
+                }
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
+
+                await chatSDK.initialize();
+
+                await chatSDK.startChat();
+
+                const runtimeContext = {
+                    requestId: chatSDK.requestId,
+                    chatId: chatSDK.chatToken.chatId,
+                    acsEndpoint: chatSDK.chatToken.acsEndpoint,
+                };
+
+                await chatSDK.sendMessage({
+                    content
+                });
+
+                await chatSDK.getMessages();
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig, content })
+        ]);
+
+        const getMessagesResponseDataJson = await getMessagesResponse.json();
+        const sentMessages = getMessagesResponseDataJson.value.filter((message) => message.type === 'text');
+        const sentMessageContent = sentMessages[0].content.message;
+
+        expect(sentMessageContent).toBe("################");
     });
 });

--- a/playwright/integrations/authenticated-chat.spec.ts
+++ b/playwright/integrations/authenticated-chat.spec.ts
@@ -1,0 +1,153 @@
+import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
+import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import { test, expect } from '@playwright/test';
+import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
+
+const testPage = fetchTestPageUrl();
+const omnichannelConfig = fetchOmnichannelConfig('AuthenticatedChat');
+
+test.describe('AuthenticatedChat @AuthenticatedChat', () => {
+
+    test('Calling ChatSDK.startChat() should not fail for authenticated Chat', async ({ page }) => {
+        await page.goto(testPage);
+
+        const [chatTokenRequest, chatTokenResponse, sessionInitRequest, sessionInitResponse, runtimeContext] = await Promise.all([
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.LiveChatv2AuthGetChatTokenPath);
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.LiveChatv2AuthGetChatTokenPath);
+            }),
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.LiveChatAuthSessionInitPath);
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.LiveChatAuthSessionInitPath);
+            }),
+            await page.evaluate(async ({ omnichannelConfig }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+                const chatSDKConfig = {
+                    getAuthToken: async () => {
+                        return omnichannelConfig.token;
+                    }
+                }
+
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
+
+                await chatSDK.initialize();
+
+                const runtimeContext = {
+                    requestId: chatSDK.requestId,
+                };
+
+                await chatSDK.startChat();
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig })
+        ]);
+
+        const { requestId } = runtimeContext;
+        const chatTokenRequestUrl = `${omnichannelConfig.orgUrl}/${OmnichannelEndpoints.LiveChatv2AuthGetChatTokenPath}/${omnichannelConfig.orgId}/${omnichannelConfig.widgetId}/${requestId}?channelId=lcw`;
+        const sessionInitRequestUrl = `${omnichannelConfig.orgUrl}/${OmnichannelEndpoints.LiveChatAuthSessionInitPath}/${omnichannelConfig.orgId}/${omnichannelConfig.widgetId}/${requestId}?channelId=lcw`;
+
+        expect(chatTokenRequest.url() === chatTokenRequestUrl).toBe(true);
+        expect(chatTokenResponse.status()).toBe(200);
+        expect(sessionInitRequest.url() === sessionInitRequestUrl).toBe(true);
+        expect(sessionInitResponse.status()).toBe(200);
+
+        const chatrequestHeaders = chatTokenRequest.headers();
+        expect(chatrequestHeaders['authenticatedusertoken']).toBe(omnichannelConfig.token);
+        const sessioninitrequestHeaders = sessionInitRequest.headers();
+        expect(sessioninitrequestHeaders['authenticatedusertoken']).toBe(omnichannelConfig.token);
+    });
+
+    test('ChatSDK.startChat() with a liveChatContext should validate the live work item details and auth chat map record & should not perform session init call', async ({ page }) => {
+        await page.goto(testPage);
+
+        const requestUrls = [];
+        page.on('request', (request) => {
+            if (request.url().includes("livechatconnector")) {
+                requestUrls.push(request.url());
+            }
+        });
+
+        const [_, liveWorkItemDetailsRequest, liveWorkItemDetailsResponse, liveChatMapRecordRequest, liveChatMapRecordResponse, runtimeContext] = await Promise.all([
+            await page.evaluate(async ({ omnichannelConfig }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+                const chatSDKConfig = {
+                    getAuthToken: async () => {
+                        return omnichannelConfig.token;
+                    }
+                }
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
+
+                await chatSDK.initialize();
+
+                await chatSDK.startChat();
+
+                const liveChatContext = await chatSDK.getCurrentLiveChatContext();
+
+                const runtimeContext = {
+                    runtimeIdFirstSession: chatSDK.runtimeId,
+                    requestIdFirstSession: chatSDK.requestId,
+                    liveChatContext,
+                };
+
+                (window as any).runtimeContext = runtimeContext;
+            }, { omnichannelConfig }),
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.LiveChatAuthLiveWorkItemDetailsPath);
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.LiveChatAuthLiveWorkItemDetailsPath);
+            }),
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.LiveChatAuthChatMapRecord);
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.LiveChatAuthChatMapRecord);
+            }),
+            await page.evaluate(async ({ omnichannelConfig }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK, runtimeContext } = window;
+
+                const chatSDKConfig = {
+                    getAuthToken: async () => {
+                        return omnichannelConfig.token;
+                    }
+                }
+
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
+
+                await chatSDK.initialize();
+
+                runtimeContext.runtimeIdSecondSession = chatSDK.runtimeId;
+                runtimeContext.requestIdSecondSession = chatSDK.requestId;
+
+                try {
+                    await chatSDK.startChat({ liveChatContext: runtimeContext.liveChatContext });
+                } catch (err) {
+                    runtimeContext.errorMessage = `${err.message}`;
+                }
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig })
+        ]);
+
+        const { requestIdFirstSession: requestId } = runtimeContext;
+        const liveWorkItemDetailsRequestUrl = `${omnichannelConfig.orgUrl}/${OmnichannelEndpoints.LiveChatAuthLiveWorkItemDetailsPath}/${omnichannelConfig.orgId}/${omnichannelConfig.widgetId}/${requestId}?channelId=lcw`;
+        const authChatMapRecordRequestUrl = `${omnichannelConfig.orgUrl}/${OmnichannelEndpoints.LiveChatAuthChatMapRecord}/${omnichannelConfig.orgId}/${omnichannelConfig.widgetId}`;
+        const liveWorkItemDetailsResponseDataJson = await liveWorkItemDetailsResponse.json();
+        const sessionInitCalls = requestUrls.filter((url) => url.includes(OmnichannelEndpoints.LiveChatAuthSessionInitPath));
+
+        expect(liveWorkItemDetailsRequest.url() === liveWorkItemDetailsRequestUrl).toBe(true);
+        expect(liveWorkItemDetailsResponse.status()).toBe(200);
+        expect(liveChatMapRecordRequest.url()).toContain(authChatMapRecordRequestUrl);
+        expect(liveChatMapRecordResponse.status()).toBe(200);
+        expect(liveWorkItemDetailsResponseDataJson.State).not.toBe('Closed');
+        expect(sessionInitCalls.length).toBe(1);
+    });
+});

--- a/playwright/integrations/unauthenticated-chat-with-masking.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-masking.spec.ts
@@ -1,0 +1,54 @@
+import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
+import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import { test, expect } from '@playwright/test';
+import ACSEndpoints from '../utils/ACSEndpoints';
+
+const testPage = fetchTestPageUrl();
+const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChat');
+
+test.describe('UnauthenticatedChat @UnauthenticatedChatWithMasking', () => {
+    test('ChatSDK.sendMessage() should send the message masked', async ({ page }) => {
+        await page.goto(testPage);
+
+        const content = "4111111111111111";
+
+        const [getMessagesRequest, getMessagesResponse, runtimeContext] = await Promise.all([
+            page.waitForRequest(request => {
+                return request.url().match(ACSEndpoints.getMessagesPathPattern)?.length >= 0 && request.method() === 'GET';
+            }),
+            page.waitForResponse(response => {
+                return response.url().match(ACSEndpoints.getMessagesPathPattern)?.length >= 0 && response.request().method() === 'GET'
+            }),
+            await page.evaluate(async ({ omnichannelConfig, content }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
+
+                await chatSDK.initialize();
+
+                await chatSDK.startChat();
+
+                const runtimeContext = {
+                    requestId: chatSDK.requestId,
+                    chatId: chatSDK.chatToken.chatId,
+                    acsEndpoint: chatSDK.chatToken.acsEndpoint,
+                };
+
+                await chatSDK.sendMessage({
+                    content
+                });
+
+                await chatSDK.getMessages();
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig, content })
+        ]);
+
+        const getMessagesResponseDataJson = await getMessagesResponse.json();
+        const sentMessages = getMessagesResponseDataJson.value.filter((message) => message.type === 'text');
+        const sentMessageContent = sentMessages[0].content.message;
+
+        expect(sentMessageContent).toBe("################");
+    });
+});

--- a/playwright/integrations/unauthenticated-chat-with-ooh.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-ooh.spec.ts
@@ -1,0 +1,40 @@
+import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
+import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import { test, expect } from '@playwright/test';
+
+const testPage = fetchTestPageUrl();
+const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChatWithOOOH');
+
+test.describe('UnauthenticatedChat @UnauthenticatedChatWithOOOH', () => {
+    //Bug 3114088: [Chat SDK] Not getting expected exception on startChart() with Outside of Operating Hours
+    test.fixme('ChatSDK.startChat() on outside of operating hours should throw an exception', async ({ page }) => {
+        await page.goto(testPage);
+
+        const [runtimeContext] = await Promise.all([
+            await page.evaluate(async ({ omnichannelConfig }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
+
+                await chatSDK.initialize();
+
+                const runtimeContext = {
+                    requestId: chatSDK.requestId,
+                };
+
+                try {
+                    await chatSDK.startChat();
+                } catch (err) {
+                    runtimeContext.errorMessage = `${err.message}`;
+                }
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig }),
+        ]);
+
+        const expectedErrorMessage = "WidgetUseOutsideOperatingHour";
+        const { errorMessage } = runtimeContext;
+        expect(errorMessage).toContain(expectedErrorMessage);
+    });
+});

--- a/playwright/integrations/unauthenticated-chat-with-prechat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-prechat.spec.ts
@@ -1,0 +1,49 @@
+import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
+import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import { test, expect } from '@playwright/test';
+import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
+
+const testPage = fetchTestPageUrl();
+const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChatWithPrechat');
+
+test.describe('UnauthenticatedChat @UnauthenticatedChatWithPrechat', () => {
+    test('ChatSDK.startChat() with preChatResponse should be part of session init payload', async ({ page }) => {
+
+        await page.goto(testPage);
+
+        const optionalParams = {
+            preChatResponse: { 'Type': "InputSubmit" }, // PreChatSurvey response
+        };
+
+        const preChatSurvey = "";
+        const [request, response, runtimeContext] = await Promise.all([
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
+            }),
+            await page.evaluate(async ({ omnichannelConfig, preChatSurvey, optionalParams }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
+                const runtimeContext = {};
+
+                await chatSDK.initialize();
+
+                await chatSDK.startChat(optionalParams);
+
+                runtimeContext.requestId = chatSDK.requestId;
+
+                preChatSurvey = await chatSDK.getPreChatSurvey();
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig, optionalParams })
+        ]);
+
+        const RequestPostData = request.postDataJSON();
+        const { preChatResponse: preChatResponseData } = RequestPostData;
+        expect(optionalParams.preChatResponse).toEqual(preChatResponseData);
+    });
+});

--- a/playwright/integrations/unauthenticated-chat-with-prechat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-prechat.spec.ts
@@ -16,7 +16,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithPrechat', () => {
         };
 
         const preChatSurvey = "";
-        const [request, response, runtimeContext] = await Promise.all([
+        const [sessionInitRequest, sessionInitResponse, runtimeContext] = await Promise.all([
             page.waitForRequest(request => {
                 return request.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
             }),
@@ -42,7 +42,12 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithPrechat', () => {
             }, { omnichannelConfig, optionalParams })
         ]);
 
-        const RequestPostData = request.postDataJSON();
+        const {requestId} = runtimeContext;
+        const sessionInitRequestUrl = `${omnichannelConfig.orgUrl}/${OmnichannelEndpoints.LiveChatSessionInitPath}/${omnichannelConfig.orgId}/${omnichannelConfig.widgetId}/${requestId}?channelId=lcw`;
+        const RequestPostData = sessionInitRequest.postDataJSON();
+
+        expect(sessionInitRequest.url() === sessionInitRequestUrl).toBe(true);
+        expect(sessionInitResponse.status()).toBe(200);
         const { preChatResponse: preChatResponseData } = RequestPostData;
         expect(optionalParams.preChatResponse).toEqual(preChatResponseData);
     });

--- a/playwright/integrations/unauthenticated-chat-with-reconnect.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-reconnect.spec.ts
@@ -1,0 +1,46 @@
+import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
+import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import { test, expect } from '@playwright/test';
+
+const testPage = fetchTestPageUrl();
+const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChatWithReconnect');
+
+test.describe('UnauthenticatedChat @UnauthenticatedChatWithReconnect', () => {
+    test('ChatSDK.getChatReconnectContext() with invalid reconnect id & redirect URL should only return a redirect URL', async ({ page }) => {
+        await page.goto(testPage);
+
+        const [chatReconnectContext] = await Promise.all([
+            await page.evaluate(async ({ omnichannelConfig }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+                const chatSDKConfig = {
+                    chatReconnect: {
+                        disable: false,
+                    },
+                }
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
+
+                await chatSDK.initialize();
+
+                const params = {
+                    reconnectId: omnichannelConfig.reconnectId
+                };
+
+                const chatReconnectContext = await chatSDK.getChatReconnectContext(params);
+
+                if (chatReconnectContext.reconnectId) {
+                    await chatSDK.startChat({
+                        reconnectId: chatReconnectContext.reconnectId
+                    });
+                }
+
+                await chatSDK.endChat();
+
+                return chatReconnectContext;
+            }, { omnichannelConfig })
+        ]);
+
+        const context = chatReconnectContext;
+        expect(context.reconnectId).toBe(null);
+        expect(context.redirectURL).toBe('https://www.microsoft.com/');
+    });
+});

--- a/playwright/integrations/unauthenticated-chat-with-reconnect.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-reconnect.spec.ts
@@ -10,7 +10,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithReconnect', () => {
     test('ChatSDK.getChatReconnectContext() with invalid reconnect id & redirect URL should only return a redirect URL', async ({ page }) => {
         await page.goto(testPage);
 
-        const [chatTokenRequest, chatTokenResponse, sessionInitRequest, sessionInitResponse, runtimeContext] = await Promise.all([
+        const [chatTokenRequest, chatTokenResponse, sessionInitRequest, sessionInitResponse, reconnectRequest, reconnectResponse, runtimeContext] = await Promise.all([
             page.waitForRequest(request => {
                 return request.url().includes(OmnichannelEndpoints.LiveChatv2GetChatTokenPath);
             }),
@@ -22,6 +22,12 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithReconnect', () => {
             }),
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
+            }),
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.LiveChatReConnect);
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.LiveChatReConnect);
             }),
             await page.evaluate(async ({ omnichannelConfig }) => {
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
@@ -57,11 +63,14 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithReconnect', () => {
         const { reconnectId, redirectURL, requestId } = runtimeContext;
         const chatTokenRequestUrl = `${omnichannelConfig.orgUrl}/${OmnichannelEndpoints.LiveChatv2GetChatTokenPath}/${omnichannelConfig.orgId}/${omnichannelConfig.widgetId}/${requestId}?channelId=lcw`;
         const sessionInitRequestUrl = `${omnichannelConfig.orgUrl}/${OmnichannelEndpoints.LiveChatSessionInitPath}/${omnichannelConfig.orgId}/${omnichannelConfig.widgetId}/${requestId}?channelId=lcw`;
+        const reconnectRequestUrl = `${omnichannelConfig.orgUrl}/${OmnichannelEndpoints.LiveChatReConnect}/${omnichannelConfig.orgId}/${omnichannelConfig.widgetId}/${omnichannelConfig.reconnectId}`;
 
         expect(chatTokenRequest.url() === chatTokenRequestUrl).toBe(true);
         expect(chatTokenResponse.status()).toBe(200);
         expect(sessionInitRequest.url() === sessionInitRequestUrl).toBe(true);
         expect(sessionInitResponse.status()).toBe(200);
+        expect(reconnectRequest.url() === reconnectRequestUrl).toBe(true);
+        expect(reconnectResponse.status()).toBe(200);
 
         expect(reconnectId).toBe(null);
         expect(redirectURL).toBe('https://www.microsoft.com/');

--- a/playwright/utils/OmnichannelEndpoints.ts
+++ b/playwright/utils/OmnichannelEndpoints.ts
@@ -13,4 +13,5 @@ export default class OmnichannelEndpoints {
     public static readonly LiveChatAuthSessionInitPath = "livechatconnector/auth/sessioninit";
     public static readonly LiveChatAuthLiveWorkItemDetailsPath = "livechatconnector/auth/getliveworkitemdetails";
     public static readonly LiveChatAuthChatMapRecord = "livechatconnector/auth/validateauthchatmaprecord";
+    public static readonly LiveChatReConnect= "livechatconnector/reconnect";
 }

--- a/playwright/utils/OmnichannelEndpoints.ts
+++ b/playwright/utils/OmnichannelEndpoints.ts
@@ -9,4 +9,8 @@ export default class OmnichannelEndpoints {
     public static readonly LiveChatTranscriptEmailRequestPath = "livechatconnector/createemailrequest";
     public static readonly LiveChatLiveWorkItemDetailsPath = "livechatconnector/getliveworkitemdetails";
     public static readonly LiveChatv2GetChatTranscriptPath = "livechatconnector/v2/getchattranscripts";
+    public static readonly LiveChatv2AuthGetChatTokenPath = "livechatconnector/v2/auth/getchattoken";
+    public static readonly LiveChatAuthSessionInitPath = "livechatconnector/auth/sessioninit";
+    public static readonly LiveChatAuthLiveWorkItemDetailsPath = "livechatconnector/auth/getliveworkitemdetails";
+    public static readonly LiveChatAuthChatMapRecord = "livechatconnector/auth/validateauthchatmaprecord";
 }

--- a/playwright/utils/fetchOmnichannelConfig.ts
+++ b/playwright/utils/fetchOmnichannelConfig.ts
@@ -8,6 +8,8 @@ const fetchOmnichannelConfig = (scenario = ""): object => {
     omnichannelConfig.orgId = testConfig["DefaultSettings"].orgId;
     omnichannelConfig.orgUrl = testConfig["DefaultSettings"].orgUrl;
     omnichannelConfig.widgetId = testConfig["DefaultSettings"].widgetId;
+    omnichannelConfig.token = testConfig["DefaultSettings"].token;
+    omnichannelConfig.reconnectId = testConfig["DefaultSettings"].reconnectId;
 
     if (!scenario) {
         return omnichannelConfig;
@@ -21,6 +23,8 @@ const fetchOmnichannelConfig = (scenario = ""): object => {
     omnichannelConfig.orgId = testConfig[scenario]?.orgId || omnichannelConfig.orgId;
     omnichannelConfig.orgUrl = testConfig[scenario]?.orgUrl || omnichannelConfig.orgUrl;
     omnichannelConfig.widgetId = testConfig[scenario]?.widgetId || omnichannelConfig.widgetId;
+    omnichannelConfig.token = testConfig[scenario]?.token || omnichannelConfig.token;
+    omnichannelConfig.reconnectId = testConfig[scenario]?.reconnectId || omnichannelConfig.reconnectId;
 
     return omnichannelConfig;
 }


### PR DESCRIPTION
This PR includes the following scenarios,

1. ChatSDK.getChatReconnectContext() with invalid reconnect id & redirect URL should only return a redirect URL.
2. ChatSDK.startChat() with preChatResponse should be part of session init payload.
3. ChatSDK.sendMessage() should send the message masked.
4. ChatSDK.startChat() with a liveChatContext should validate the live work item details and auth chat map record & should not perform session init call.
5. Calling ChatSDK.startChat() should not fail for authenticated Chat.
6. ChatSDK.sendMessage() should send the message masked for authenticated chat.
7. ChatSDK.startChat() with sendDefaultInitContext should send default init contexts.